### PR TITLE
set whitelist_attributes option only if AR is actually enabled

### DIFF
--- a/lib/protected_attributes/railtie.rb
+++ b/lib/protected_attributes/railtie.rb
@@ -2,10 +2,10 @@ module ProtectedAttributes
   class Railtie < ::Rails::Railtie
     config.before_configuration do |app|
       config.action_controller.permit_all_parameters = true
-      config.active_record.whitelist_attributes = true
+      config.active_record.whitelist_attributes = true if config.respond_to?(:active_record)
 
       ActiveSupport.on_load(:active_record) do
-        if app.config.active_record.delete(:whitelist_attributes)
+        if app.config.respond_to?(:active_record) && app.config.active_record.delete(:whitelist_attributes)
           attr_accessible(nil)
         end
       end


### PR DESCRIPTION
Check if active_record is enabled. If not, don't set active_record.whitelist_attributes. #3
