### PR TITLE
Sync #initialize override to latest rails implementation

### DIFF
--- a/lib/active_record/mass_assignment_security/core.rb
+++ b/lib/active_record/mass_assignment_security/core.rb
@@ -9,6 +9,7 @@ module ActiveRecord
         @columns_hash = self.class.column_types.dup
 
         init_internals
+        init_changed_attributes
         ensure_proper_type
         populate_with_current_scope_attributes
 


### PR DESCRIPTION
It's too bad this needs to get synced every time there's a change in ActiveRecord's implementation, but this syncs up `#initialize` after this changed was committed: https://github.com/rails/rails/commit/558f3204463eea80dc32b6748fe8b4174ec7ff14

Would be great if we could work with the rails project for a better implementation, but this is a quick win for now.
