### PR TITLE
Release 1.0.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+## 1.0.2 (June 25, 2013)
+
+* Sync #initialize override to latest rails implementation
+
+  Fixes rails/protected_attributes#14
+
+
 ## 1.0.1 (April 6, 2013)
 
 * Fix "uninitialized constant `ActiveRecord::SchemaMigration`" error

--- a/lib/protected_attributes/version.rb
+++ b/lib/protected_attributes/version.rb
@@ -1,3 +1,3 @@
 module ProtectedAttributes
-  VERSION = "1.0.1"
+  VERSION = "1.0.2"
 end


### PR DESCRIPTION
With Rails 4 officially released, we should bump the version so that users aren't affected by #14.

@rafaelfranca
