### PR TITLE
Remove default enabling of whitelist attributes

### DIFF
--- a/lib/protected_attributes/railtie.rb
+++ b/lib/protected_attributes/railtie.rb
@@ -4,7 +4,6 @@ module ProtectedAttributes
   class Railtie < ::Rails::Railtie
     config.before_configuration do |app|
       config.action_controller.permit_all_parameters = true
-      config.active_record.whitelist_attributes = true if config.respond_to?(:active_record)
     end
 
     initializer "protected_attributes.active_record", :before => "active_record.set_configs" do |app|


### PR DESCRIPTION
The behavior of the gem currently differs from how Protected Attributes acted in Rails `3.x` in that whitelist attributes gets turned on by default if the app's config has an `active_record` hash/block defined.  In Rails `3.x`, if you left the `whitelist_attributes` line commented out on your config file, it would not be enabled by default, wheras the gem now seems to be enabling it by default.  I've modified the code to remove the enabling of whitelist attributes by default.

Without this pull request, the user has to manually go in and declare:

``` ruby
config.active_record.whitelist_attributes = false
```

on their `config/application.rb` if they wish to disable whitelist attributes.  The mention of the whitelist attributes feature in the [`Usage` section of the README](https://github.com/rails/protected_attributes#usage) makes it seem as though the behavior should be working like this, unless I'm misreading it.
