### PR TITLE
Update Gemfile to point to rails 4-1-stable

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,6 +1,6 @@
 source 'https://rubygems.org'
 
-gem 'rails', github: 'rails/rails', branch: 'master'
-gem 'arel', github: 'rails/arel', branch: 'master'
+gem 'rails', github: 'rails/rails', branch: '4-1-stable'
+gem 'arel', github: 'rails/arel', branch: '5-0-stable'
 
 gemspec


### PR DESCRIPTION
Without this change, many tests fail due to incompatible changes to arel. For example...

```
 95) Error:
MassAssignmentSecurityNestedAttributesTest#test_mass_assignment_options_are_reset_after_exception:
ArgumentError: wrong number of arguments (1 for 2)
    /Users/anchambers/.rbenv/versions/2.0.0-p247/lib/ruby/gems/2.0.0/bundler/gems/arel-de916331c353/lib/arel/visitors/reduce.rb:6:in `accept'
    /Users/anchambers/.rbenv/versions/2.0.0-p247/lib/ruby/gems/2.0.0/bundler/gems/rails-5f72fc6af8ad/activerecord/lib/active_record/connection_adapters/abstract/database_statements.rb:13:in `to_sql'
    /Users/anchambers/.rbenv/versions/2.0.0-p247/lib/ruby/gems/2.0.0/bundler/gems/rails-5f72fc6af8ad/activerecord/lib/active_record/connection_adapters/abstract/database_statements.rb:94:in `insert'
    /Users/anchambers/.rbenv/versions/2.0.0-p247/lib/ruby/gems/2.0.0/bundler/gems/rails-5f72fc6af8ad/activerecord/lib/active_record/connec
```
