### PR TITLE
Updating the README with details about :strict

### DIFF
--- a/README.md
+++ b/README.md
@@ -107,6 +107,18 @@ class AccountsController < ApplicationController
   end
 end
 ```
+
+### Errors
+
+By default, errors will not be raised if the user passes attributes in the params hash which are not allowed to be updated.
+If you want the functionality where exceptions (`ActiveModel::MassAssignmentSecurity::Error`) are raised.  Add to your config
+the strict flag:
+
+```ruby
+config.active_record.mass_assignment_sanitizer = :strict
+```
+
+
 ## Contributing
 
 1. Fork it


### PR DESCRIPTION
I was just updating a rails 3 app, and one of my tests was failing as it was expecting an `ActiveModel::MassAssignmentSecurity::Error` to be raised when a protected attribute was being sent through.

This just adds the `:strict` information to the README.

Thanks for the great work, now that the tests are all green I can go about removing this gem ... but this certainly made the transition process easier - so thanks very much! :+1: 
