### PR TITLE
fix broken through_association from addition of build_record method in rails

### DIFF
--- a/lib/active_record/mass_assignment_security/associations.rb
+++ b/lib/active_record/mass_assignment_security/associations.rb
@@ -90,6 +90,17 @@ module ActiveRecord
       private :options_for_through_record
     end
 
+    module ThroughAssociation
+      def build_record(attributes, options)
+        reflection.build_association(attributes, options) do |record|
+          skip_assign = [reflection.foreign_key, reflection.type].compact
+          attributes = create_scope.except(*(record.changed - skip_assign))
+          record.assign_attributes(attributes, :without_protection => true)
+        end
+      end
+      private :build_record
+    end
+
     class SingularAssociation
       def create(attributes = {}, options = {}, &block)
         create_record(attributes, options, &block)


### PR DESCRIPTION
fixes #53 

@rafaelfranca I noticed when I first commented on #53 that I was running from rails 4.2.0.beta2 locally and that was why there was 119 failures. I updated to Rails 4.2.0 and all tests were passing. I then set my Gemfile to Rails 4-2-stable and saw the `test_has_many_through_build_with_attr_accessible_attributes` fail with the same error as @dandlezzz:
`ArgumentError (wrong number of arguments (2 for 1))`

I looked back at Rails 3.2 to see how the `ThroughAssociation` was handling `build_record` and saw that it was just using the base `Association` class implementation so I copied that over into a monkey patch for `ThroughAssociation`. This fixes the failure and all tests now pass again. Let me know if this is good for you, happy to make updates.