### PR TITLE
Fix has-many-through assocs on Rails 4.1.10 -- issue #63

### DIFF
--- a/lib/active_record/mass_assignment_security/associations.rb
+++ b/lib/active_record/mass_assignment_security/associations.rb
@@ -65,6 +65,22 @@ module ActiveRecord
       end
     end
 
+    module ThroughAssociation
+
+      private
+
+        def build_record(attributes, options={})
+          inverse = source_reflection.inverse_of
+          target = through_association.target
+
+          if inverse && target && !target.is_a?(Array)
+            attributes[inverse.foreign_key] = target.id
+          end
+
+          super(attributes, options)
+        end
+    end
+
     class HasManyThroughAssociation
       def build_record(attributes, options = {})
         ensure_not_nested


### PR DESCRIPTION
Rails 4.1.10 (via commit 7d8e56a) introduces a build_record method into
the ThroughAssociation module.  To keep working with this release,
protected_attributes needs to hook that method to add the options hash.

(No tests added here, as the code already fails a pre-existing test with
this Rails release.)

NB I have *not* checked compatibility with other Rails releases than
4.1.10.rc2, though I presume Travis will be along to do that presently.