### PR TITLE
Make sure find_or_* and first_or_* methods are overridden

### DIFF
--- a/lib/active_record/mass_assignment_security.rb
+++ b/lib/active_record/mass_assignment_security.rb
@@ -19,7 +19,6 @@ class ActiveRecord::Base
   include ActiveRecord::MassAssignmentSecurity::Core
   include ActiveRecord::MassAssignmentSecurity::AttributeAssignment
   include ActiveRecord::MassAssignmentSecurity::Persistence
-  include ActiveRecord::MassAssignmentSecurity::Relation
   include ActiveRecord::MassAssignmentSecurity::Validations
   include ActiveRecord::MassAssignmentSecurity::NestedAttributes
   include ActiveRecord::MassAssignmentSecurity::Inheritance

--- a/lib/active_record/mass_assignment_security/relation.rb
+++ b/lib/active_record/mass_assignment_security/relation.rb
@@ -3,6 +3,9 @@ module ActiveRecord
     undef :first_or_create
     undef :first_or_create!
     undef :first_or_initialize
+    undef :find_or_initialize_by
+    undef :find_or_create_by
+    undef :find_or_create_by!
 
     # Tries to load the first record; if it fails, then <tt>create</tt> is called with the same arguments as this method.
     #
@@ -44,6 +47,18 @@ module ActiveRecord
     # Expects arguments in the same format as <tt>Base.new</tt>.
     def first_or_initialize(attributes = nil, options = {}, &block)
       first || new(attributes, options, &block)
+    end
+
+    def find_or_initialize_by(attributes, options = {}, &block)
+      find_by(attributes) || new(attributes, options, &block)
+    end
+
+    def find_or_create_by(attributes, options = {}, &block)
+      find_by(attributes) || create(attributes, options, &block)
+    end
+
+    def find_or_create_by!(attributes, options = {}, &block)
+      find_by(attributes) || create!(attributes, options, &block)
     end
   end
 end

--- a/lib/active_record/mass_assignment_security/relation.rb
+++ b/lib/active_record/mass_assignment_security/relation.rb
@@ -61,4 +61,16 @@ module ActiveRecord
       find_by(attributes) || create!(attributes, options, &block)
     end
   end
+
+  module QueryMethods
+    protected
+
+    def sanitize_forbidden_attributes(attributes) #:nodoc:
+      if !model._uses_mass_assignment_security
+        sanitize_for_mass_assignment(attributes)
+      else
+        attributes
+      end
+    end
+  end
 end

--- a/lib/active_record/mass_assignment_security/relation.rb
+++ b/lib/active_record/mass_assignment_security/relation.rb
@@ -1,47 +1,49 @@
 module ActiveRecord
-  module MassAssignmentSecurity
-    module Relation
-      # Tries to load the first record; if it fails, then <tt>create</tt> is called with the same arguments as this method.
-      #
-      # Expects arguments in the same format as +Base.create+.
-      #
-      # ==== Examples
-      #   # Find the first user named Penélope or create a new one.
-      #   User.where(:first_name => 'Penélope').first_or_create
-      #   # => <User id: 1, first_name: 'Penélope', last_name: nil>
-      #
-      #   # Find the first user named Penélope or create a new one.
-      #   # We already have one so the existing record will be returned.
-      #   User.where(:first_name => 'Penélope').first_or_create
-      #   # => <User id: 1, first_name: 'Penélope', last_name: nil>
-      #
-      #   # Find the first user named Scarlett or create a new one with a particular last name.
-      #   User.where(:first_name => 'Scarlett').first_or_create(:last_name => 'Johansson')
-      #   # => <User id: 2, first_name: 'Scarlett', last_name: 'Johansson'>
-      #
-      #   # Find the first user named Scarlett or create a new one with a different last name.
-      #   # We already have one so the existing record will be returned.
-      #   User.where(:first_name => 'Scarlett').first_or_create do |user|
-      #     user.last_name = "O'Hara"
-      #   end
-      #   # => <User id: 2, first_name: 'Scarlett', last_name: 'Johansson'>
-      def first_or_create(attributes = nil, options = {}, &block)
-        first || create(attributes, options, &block)
-      end
+  class Relation
+    undef :first_or_create
+    undef :first_or_create!
+    undef :first_or_initialize
 
-      # Like <tt>first_or_create</tt> but calls <tt>create!</tt> so an exception is raised if the created record is invalid.
-      #
-      # Expects arguments in the same format as <tt>Base.create!</tt>.
-      def first_or_create!(attributes = nil, options = {}, &block)
-        first || create!(attributes, options, &block)
-      end
+    # Tries to load the first record; if it fails, then <tt>create</tt> is called with the same arguments as this method.
+    #
+    # Expects arguments in the same format as +Base.create+.
+    #
+    # ==== Examples
+    #   # Find the first user named Penélope or create a new one.
+    #   User.where(:first_name => 'Penélope').first_or_create
+    #   # => <User id: 1, first_name: 'Penélope', last_name: nil>
+    #
+    #   # Find the first user named Penélope or create a new one.
+    #   # We already have one so the existing record will be returned.
+    #   User.where(:first_name => 'Penélope').first_or_create
+    #   # => <User id: 1, first_name: 'Penélope', last_name: nil>
+    #
+    #   # Find the first user named Scarlett or create a new one with a particular last name.
+    #   User.where(:first_name => 'Scarlett').first_or_create(:last_name => 'Johansson')
+    #   # => <User id: 2, first_name: 'Scarlett', last_name: 'Johansson'>
+    #
+    #   # Find the first user named Scarlett or create a new one with a different last name.
+    #   # We already have one so the existing record will be returned.
+    #   User.where(:first_name => 'Scarlett').first_or_create do |user|
+    #     user.last_name = "O'Hara"
+    #   end
+    #   # => <User id: 2, first_name: 'Scarlett', last_name: 'Johansson'>
+    def first_or_create(attributes = nil, options = {}, &block)
+      first || create(attributes, options, &block)
+    end
 
-      # Like <tt>first_or_create</tt> but calls <tt>new</tt> instead of <tt>create</tt>.
-      #
-      # Expects arguments in the same format as <tt>Base.new</tt>.
-      def first_or_initialize(attributes = nil, &block)
-        first || new(attributes, options, &block)
-      end
+    # Like <tt>first_or_create</tt> but calls <tt>create!</tt> so an exception is raised if the created record is invalid.
+    #
+    # Expects arguments in the same format as <tt>Base.create!</tt>.
+    def first_or_create!(attributes = nil, options = {}, &block)
+      first || create!(attributes, options, &block)
+    end
+
+    # Like <tt>first_or_create</tt> but calls <tt>new</tt> instead of <tt>create</tt>.
+    #
+    # Expects arguments in the same format as <tt>Base.new</tt>.
+    def first_or_initialize(attributes = nil, options = {}, &block)
+      first || new(attributes, options, &block)
     end
   end
 end

--- a/test/attribute_sanitization_test.rb
+++ b/test/attribute_sanitization_test.rb
@@ -441,6 +441,82 @@ class MassAssignmentSecurityRelationTest < ActiveSupport::TestCase
   end
 end
 
+class MassAssignmentSecurityFindersTest < ActiveSupport::TestCase
+  include MassAssignmentTestHelpers
+
+  def test_find_or_initialize_by_with_attr_accessible_attributes
+    p = TightPerson.find_or_initialize_by(attributes_hash)
+
+    assert_default_attributes(p)
+  end
+
+  def test_find_or_initialize_by_with_admin_role_with_attr_accessible_attributes
+    p = TightPerson.find_or_initialize_by(attributes_hash, as: :admin)
+
+    assert_admin_attributes(p)
+  end
+
+  def test_find_or_initialize_by_with_attr_protected_attributes
+    p = LoosePerson.find_or_initialize_by(attributes_hash)
+
+    assert_default_attributes(p)
+  end
+
+  def test_find_or_initialize_by_with_admin_role_with_attr_protected_attributes
+    p = LoosePerson.find_or_initialize_by(attributes_hash, as: :admin)
+
+    assert_admin_attributes(p)
+  end
+
+  def test_find_or_create_by_with_attr_accessible_attributes
+    p = TightPerson.find_or_create_by(attributes_hash)
+
+    assert_default_attributes(p, true)
+  end
+
+  def test_find_or_create_by_with_admin_role_with_attr_accessible_attributes
+    p = TightPerson.find_or_create_by(attributes_hash, as: :admin)
+
+    assert_admin_attributes(p, true)
+  end
+
+  def test_find_or_create_by_with_attr_protected_attributes
+    p = LoosePerson.find_or_create_by(attributes_hash)
+
+    assert_default_attributes(p, true)
+  end
+
+  def test_find_or_create_by_with_admin_role_with_attr_protected_attributes
+    p = LoosePerson.find_or_create_by(attributes_hash, as: :admin)
+
+    assert_admin_attributes(p, true)
+  end
+
+  def test_find_or_create_by_bang_with_attr_accessible_attributes
+    p = TightPerson.find_or_create_by!(attributes_hash)
+
+    assert_default_attributes(p, true)
+  end
+
+  def test_find_or_create_by_bang_with_admin_role_with_attr_accessible_attributes
+    p = TightPerson.find_or_create_by!(attributes_hash, as: :admin)
+
+    assert_admin_attributes(p, true)
+  end
+
+  def test_find_or_create_by_bang_with_attr_protected_attributes
+    p = LoosePerson.find_or_create_by!(attributes_hash)
+
+    assert_default_attributes(p, true)
+  end
+
+  def test_find_or_create_by_bang_with_admin_role_with_attr_protected_attributes
+    p = LoosePerson.find_or_create_by!(attributes_hash, as: :admin)
+
+    assert_admin_attributes(p, true)
+  end
+end
+
 if active_record_40?
   # This class should be deleted when we remove activerecord-deprecated_finders as a
   # dependency.

--- a/test/attribute_sanitization_test.rb
+++ b/test/attribute_sanitization_test.rb
@@ -365,6 +365,81 @@ class AttributeSanitizationTest < ActiveSupport::TestCase
   end
 end
 
+class MassAssignmentSecurityRelationTest < ActiveSupport::TestCase
+  include MassAssignmentTestHelpers
+
+  def test_find_or_initialize_by_with_attr_accessible_attributes
+    p = TightPerson.where(first_name: 'Josh').first_or_initialize(attributes_hash)
+
+    assert_default_attributes(p)
+  end
+
+  def test_find_or_initialize_by_with_admin_role_with_attr_accessible_attributes
+    p = TightPerson.where(first_name: 'Josh').first_or_initialize(attributes_hash, as: :admin)
+
+    assert_admin_attributes(p)
+  end
+
+  def test_find_or_initialize_by_with_attr_protected_attributes
+    p = LoosePerson.where(first_name: 'Josh').first_or_initialize(attributes_hash)
+
+    assert_default_attributes(p)
+  end
+
+  def test_find_or_initialize_by_with_admin_role_with_attr_protected_attributes
+    p = LoosePerson.where(first_name: 'Josh').first_or_initialize(attributes_hash, as: :admin)
+
+    assert_admin_attributes(p)
+  end
+
+  def test_find_or_create_by_with_attr_accessible_attributes
+    p = TightPerson.where(first_name: 'Josh').first_or_create(attributes_hash)
+
+    assert_default_attributes(p, true)
+  end
+
+  def test_find_or_create_by_with_admin_role_with_attr_accessible_attributes
+    p = TightPerson.where(first_name: 'Josh').first_or_create(attributes_hash, as: :admin)
+
+    assert_admin_attributes(p, true)
+  end
+
+  def test_find_or_create_by_with_attr_protected_attributes
+    p = LoosePerson.where(first_name: 'Josh').first_or_create(attributes_hash)
+
+    assert_default_attributes(p, true)
+  end
+
+  def test_find_or_create_by_with_admin_role_with_attr_protected_attributes
+    p = LoosePerson.where(first_name: 'Josh').first_or_create(attributes_hash, as: :admin)
+
+    assert_admin_attributes(p, true)
+  end
+
+  def test_find_or_create_by_bang_with_attr_accessible_attributes
+    p = TightPerson.where(first_name: 'Josh').first_or_create!(attributes_hash)
+
+    assert_default_attributes(p, true)
+  end
+
+  def test_find_or_create_by_bang_with_admin_role_with_attr_accessible_attributes
+    p = TightPerson.where(first_name: 'Josh').first_or_create!(attributes_hash, as: :admin)
+
+    assert_admin_attributes(p, true)
+  end
+
+  def test_find_or_create_by_bang_with_attr_protected_attributes
+    p = LoosePerson.where(first_name: 'Josh').first_or_create!(attributes_hash)
+
+    assert_default_attributes(p, true)
+  end
+
+  def test_find_or_create_by_bang_with_admin_role_with_attr_protected_attributes
+    p = LoosePerson.where(first_name: 'Josh').first_or_create!(attributes_hash, as: :admin)
+
+    assert_admin_attributes(p, true)
+  end
+end
 
 if active_record_40?
   # This class should be deleted when we remove activerecord-deprecated_finders as a

--- a/test/mass_assignment_security/strong_parameters_fallback_test.rb
+++ b/test/mass_assignment_security/strong_parameters_fallback_test.rb
@@ -14,6 +14,12 @@ class StrongParametersFallbackTest < ActiveModel::TestCase
 
     assert_raises(ActiveModel::ForbiddenAttributesError) { Keyboard.new untrusted_params }
     assert_raises(ActiveModel::ForbiddenAttributesError) { Keyboard.new.attributes = untrusted_params }
+    assert_raises(ActiveModel::ForbiddenAttributesError) { Keyboard.where(key_number: 6).first_or_initialize(untrusted_params) }
+    assert_raises(ActiveModel::ForbiddenAttributesError) { Keyboard.where(key_number: 6).first_or_create(untrusted_params) }
+    assert_raises(ActiveModel::ForbiddenAttributesError) { Keyboard.where(key_number: 6).first_or_create!(untrusted_params) }
+    assert_raises(ActiveModel::ForbiddenAttributesError) { Keyboard.find_or_initialize_by(untrusted_params) }
+    assert_raises(ActiveModel::ForbiddenAttributesError) { Keyboard.find_or_create_by(untrusted_params) }
+    assert_raises(ActiveModel::ForbiddenAttributesError) { Keyboard.find_or_create_by!(untrusted_params) }
   end
 
   test "AR, ignore strong parameters when protection macro was used" do
@@ -21,6 +27,12 @@ class StrongParametersFallbackTest < ActiveModel::TestCase
 
     assert_nothing_raised { TightPerson.new untrusted_params }
     assert_nothing_raised { TightPerson.new.attributes = untrusted_params }
+    assert_nothing_raised { TightPerson.where(first_name: "John").first_or_initialize(untrusted_params) }
+    assert_nothing_raised { TightPerson.where(first_name: "John").first_or_create(untrusted_params) }
+    assert_nothing_raised { TightPerson.where(first_name: "John").first_or_create!(untrusted_params) }
+    assert_nothing_raised { TightPerson.find_or_initialize_by(untrusted_params) }
+    assert_nothing_raised { TightPerson.find_or_create_by(untrusted_params) }
+    assert_nothing_raised { TightPerson.find_or_create_by!(untrusted_params) }
   end
 
   test "with PORO including MassAssignmentSecurity that uses a protection marco" do


### PR DESCRIPTION
There methods were not being overridden and were only using strong parameters protection even if we include this gem. Now they are respecting the model macros.

Fixes #40.

cc @senny 