### PR TITLE
[FIX] TooManyRecords exception is defined in NestedAttributes not MasAssignmentSecurity

### DIFF
--- a/lib/active_record/mass_assignment_security/nested_attributes.rb
+++ b/lib/active_record/mass_assignment_security/nested_attributes.rb
@@ -87,7 +87,7 @@ module ActiveRecord
           end
 
           if limit && attributes_collection.size > limit
-            raise TooManyRecords, "Maximum #{limit} records are allowed. Got #{attributes_collection.size} records instead."
+            raise ActiveRecord::NestedAttributes::TooManyRecords, "Maximum #{limit} records are allowed. Got #{attributes_collection.size} records instead."
           end
         end
 


### PR DESCRIPTION
When this cdoe path is hit, I am getting:
uninitialized constant ActiveRecord::MassAssignmentSecurity::NestedAttributes::TooManyRecords

This is because TooManyRecords is actually defined in 
ActiveRecord::MassAssignmentSecurity::TooManyRecords

Now, I'm quite there is a more clever way to get to it on the class hierarchy, without spelling out the absolute hierarchy, but I haven't found it in a quick search. :(