### PR TITLE
Reject blank ids so that they did not accidentally go into query for existing records

### DIFF
--- a/lib/active_record/mass_assignment_security/nested_attributes.rb
+++ b/lib/active_record/mass_assignment_security/nested_attributes.rb
@@ -105,7 +105,7 @@ module ActiveRecord
         existing_records = if association.loaded?
           association.target
         else
-          attribute_ids = attributes_collection.map {|a| a['id'] || a[:id] }.compact
+          attribute_ids = attributes_collection.map { |a| a['id'] || a[:id] }.reject { |a| a.blank? }
           attribute_ids.empty? ? [] : association.scope.where(association.klass.primary_key => attribute_ids)
         end
 


### PR DESCRIPTION
- For an attribute collection like -

  [{"id" => 1}, {"id" => "'"}]

  attribute_ids will become [1, ""] as per existing code.

- As the first element of attribute collection has a valid id, we try to
  load "existing records" with attribute_ids [1, ""] resulting into an
  error on (PG) database adapter.

- After this change, the attribute_ids will reject all the blank values
  so that the query will be unaffected.