### PR TITLE
Avoid double callbacks in Rails >= 4.1

### DIFF
--- a/lib/active_record/mass_assignment_security/nested_attributes.rb
+++ b/lib/active_record/mass_assignment_security/nested_attributes.rb
@@ -15,7 +15,11 @@ module ActiveRecord
 
           attr_names.each do |association_name|
             if reflection = reflect_on_association(association_name)
-              reflection.options[:autosave] = true
+              if active_record_40?
+                reflection.options[:autosave] = true
+              else
+                reflection.autosave = true
+              end
               add_autosave_association_callbacks(reflection)
 
               nested_attributes_options = self.nested_attributes_options.dup

--- a/test/attribute_sanitization_test.rb
+++ b/test/attribute_sanitization_test.rb
@@ -1225,4 +1225,15 @@ class MassAssignmentSecurityNestedAttributesTest < ActiveSupport::TestCase
     assert_equal 'Josh', person.best_friend.first_name
     assert_equal 'f', person.best_friend.gender
   end
+
+  def test_accepts_nested_attributes_for_and_protected_attributes_on_both_sides
+    team = Team.create
+
+    team.update_attributes({ :nested_battles_attributes => {
+      '0' => { :team_id => Team.create.id },
+      '1' => { :team_id => Team.create.id } }
+    })
+
+    assert_equal 2, Team.find(team.id).nested_battles.count
+  end
 end

--- a/test/models/battle.rb
+++ b/test/models/battle.rb
@@ -3,3 +3,12 @@ class Battle < ActiveRecord::Base
   belongs_to :team
   belongs_to :battle, :polymorphic => true
 end
+
+class NestedBattle < ActiveRecord::Base
+  self.table_name = "battles"
+
+  belongs_to :team
+  belongs_to :battle, :polymorphic => true
+
+  accepts_nested_attributes_for :team
+end

--- a/test/models/team.rb
+++ b/test/models/team.rb
@@ -2,4 +2,7 @@ class Team < ActiveRecord::Base
   has_many :battles
   has_many :wolf_battles, :through => :battles, :class_name => 'Wolf', :source => :battle, :source_type => 'Wolf'
   has_many :vampire_battles, :through => :battles, :class_name => 'Vampire', :source => :battle, :source_type => 'Vampire'
+  has_many :nested_battles
+
+  accepts_nested_attributes_for :nested_battles
 end


### PR DESCRIPTION
This PR provides the same solution like https://github.com/rails/protected_attributes/pull/78 but I've added a test.

I wasn't able to use any person model combination to reproduce the problem that's why I've added the `NestedBattle` model