### PR TITLE
Drop 1.9.3 tests from travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,6 @@ language: ruby
 sudo: false
 cache: bundler
 rvm:
-  - 1.9.3
   - 2.0.0
   - 2.1
   - 2.2


### PR DESCRIPTION
@rafaelfranca can we drop 1.9.3 tests from travis?

They are failing right now, mostly because dependencies cannot be installed for 1.9.3 anymore.