### PR TITLE
Fixes the Activerecord::TooManyRecords namespace:

### DIFF
--- a/lib/active_record/mass_assignment_security/nested_attributes.rb
+++ b/lib/active_record/mass_assignment_security/nested_attributes.rb
@@ -91,7 +91,7 @@ module ActiveRecord
           end
 
           if limit && attributes_collection.size > limit
-            raise TooManyRecords, "Maximum #{limit} records are allowed. Got #{attributes_collection.size} records instead."
+            raise ::ActiveRecord::NestedAttributes::TooManyRecords, "Maximum #{limit} records are allowed. Got #{attributes_collection.size} records instead."
           end
         end
 

--- a/test/attribute_sanitization_test.rb
+++ b/test/attribute_sanitization_test.rb
@@ -1236,4 +1236,17 @@ class MassAssignmentSecurityNestedAttributesTest < ActiveSupport::TestCase
 
     assert_equal 2, Team.find(team.id).nested_battles.count
   end
+
+  def test_accepts_nested_attributes_for_raises_when_limit_is_reached
+    team = Team.create
+    team.nested_attributes_options[:nested_battles].merge!(limit: 2)
+
+    assert_raises(ActiveRecord::NestedAttributes::TooManyRecords) do
+      team.nested_battles_attributes = {
+        '0' => { :team_id => Team.create.id },
+        '1' => { :team_id => Team.create.id },
+        '2' => { :team_id => Team.create.id }
+      }
+    end
+  end
 end


### PR DESCRIPTION
- Class `TooManyRecords` was in the `ActiveRecord::MassAssignmentSecurity::NestedAttributes` namespace, resulting in a `UnitializedConstant` exception

Not too sure if I should add a test for this.

Thanks :)