### PR TITLE
attribute_sanitization_test: avoid random failures

### DIFF
--- a/test/attribute_sanitization_test.rb
+++ b/test/attribute_sanitization_test.rb
@@ -16,6 +16,7 @@ require 'models/wolf'
 
 module MassAssignmentTestHelpers
   def teardown
+    super
     ActiveRecord::Base.send(:descendants).each do |klass|
       begin
         klass.delete_all


### PR DESCRIPTION
Because test/test_helper.rb sets the tests to run on random order, that
missing call to `super` will cause tests to crash with the following
exception, depending on which order the test classes get loaded.

```
ActiveRecord::RecordNotUnique: SQLite3::ConstraintException: UNIQUE
constraint failed: people.id: INSERT INTO "people" ("id", "first_name", "gender", "comments", "best_friend_id", "created_at", "updated_at") VALUES (?, ?, ?, ?, ?, ?, ?)
```

On my tests, this seems to happen more or less 6% of the time (i.e. 3
out of 50 runs). With this change, I was able to make 50 runs without a
single failure.