### PR TITLE
Don't pollute toplevel with active_record_40? method

### DIFF
--- a/lib/active_record/mass_assignment_security.rb
+++ b/lib/active_record/mass_assignment_security.rb
@@ -1,9 +1,5 @@
 require "active_record"
 
-def active_record_40?
-  ActiveRecord::VERSION::MAJOR == 4 && ActiveRecord::VERSION::MINOR == 0
-end
-
 require "active_record/mass_assignment_security/associations"
 require "active_record/mass_assignment_security/attribute_assignment"
 require "active_record/mass_assignment_security/core"

--- a/lib/active_record/mass_assignment_security/nested_attributes.rb
+++ b/lib/active_record/mass_assignment_security/nested_attributes.rb
@@ -15,7 +15,7 @@ module ActiveRecord
 
           attr_names.each do |association_name|
             if reflection = reflect_on_association(association_name)
-              if active_record_40?
+              if ActiveRecord::VERSION::MAJOR == 4 && ActiveRecord::VERSION::MINOR == 0
                 reflection.options[:autosave] = true
               else
                 reflection.autosave = true
@@ -28,7 +28,7 @@ module ActiveRecord
 
               type = (reflection.collection? ? :collection : :one_to_one)
 
-              generated_methods_module = active_record_40? ? generated_feature_methods : generated_association_methods
+              generated_methods_module = (ActiveRecord::VERSION::MAJOR == 4 && ActiveRecord::VERSION::MINOR == 0) ? generated_feature_methods : generated_association_methods
 
               # def pirate_attributes=(attributes)
               #   assign_nested_attributes_for_one_to_one_association(:pirate, attributes, mass_assignment_options)

--- a/test/attribute_sanitization_test.rb
+++ b/test/attribute_sanitization_test.rb
@@ -257,12 +257,12 @@ class AttributeSanitizationTest < ActiveSupport::TestCase
      :connection_handler, :nested_attributes_options,
      :attribute_method_matchers, :time_zone_aware_attributes, :skip_time_zone_conversion_for_attributes]
 
-    attribute_writers.push(:_attr_readonly) if active_record_40?
+    attribute_writers.push(:_attr_readonly) if ActiveRecord::VERSION::MAJOR == 4 && ActiveRecord::VERSION::MINOR == 0
 
     attribute_writers.each do |method|
       assert_respond_to Task, method
       assert_respond_to Task, "#{method}="
-      assert_respond_to Task.new, method unless method == :configurations && !active_record_40?
+      assert_respond_to Task.new, method unless method == :configurations && !(ActiveRecord::VERSION::MAJOR == 4 && ActiveRecord::VERSION::MINOR == 0)
       assert !Task.new.respond_to?("#{method}=")
     end
   end
@@ -518,7 +518,7 @@ class MassAssignmentSecurityFindersTest < ActiveSupport::TestCase
   end
 end
 
-if active_record_40?
+if ActiveRecord::VERSION::MAJOR == 4 && ActiveRecord::VERSION::MINOR == 0
   # This class should be deleted when we remove activerecord-deprecated_finders as a
   # dependency.
   class MassAssignmentSecurityDeprecatedFindersTest < ActiveSupport::TestCase


### PR DESCRIPTION
Since `active_record_40?` method for this plugin internal use is defined on toplevel, this method can actually be called from anywhere in our apps.

e.g.
```
% rails r "p active_record_40?"
false
```

This situation can be improved by moving the method under ActiveRecord module, or maybe elegantly by using refinements, but I just copied the whole logic 5 times here and there in the gem, because it's just a single line of straight forward Ruby code.