### PR TITLE
require mocha/minitest

### DIFF
--- a/protected_attributes.gemspec
+++ b/protected_attributes.gemspec
@@ -22,5 +22,5 @@ Gem::Specification.new do |gem|
   gem.add_development_dependency "actionpack",   ">= 4.0.1", "< 5.0"
   gem.add_development_dependency "railties",   ">= 4.0.1", "< 5.0"
   gem.add_development_dependency "sqlite3"
-  gem.add_development_dependency "mocha", "< 1.5"
+  gem.add_development_dependency "mocha"
 end

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -1,6 +1,6 @@
 require 'bundler/setup'
 require 'minitest/autorun'
-require 'mocha/api'
+require 'mocha/minitest'
 require 'rails'
 
 ActiveSupport.test_order = :random if ActiveSupport.respond_to?(:test_order)


### PR DESCRIPTION
require mocha/minitest instead of mocha/api as suggested by mocha developers.

See https://github.com/freerange/mocha/issues/348#issuecomment-436961346