### PR TITLE
Re-alias #attributes= method

### DIFF
--- a/lib/active_record/mass_assignment_security/attribute_assignment.rb
+++ b/lib/active_record/mass_assignment_security/attribute_assignment.rb
@@ -74,6 +74,9 @@ module ActiveRecord
         @mass_assignment_options = previous_options
       end
 
+      # alias attributes= so it points to the new assign_attributes method
+      alias attributes= assign_attributes
+
       protected
 
       def mass_assignment_options


### PR DESCRIPTION
Hi,

While upgrading an old app to rails 4, I got weird errors from `record.attributes =`.
I tracked the issue to be rails's `assign_attributes` method being called instead of the one provided by this gem, re-aliasing `attributes=` solves the issue.

Thanks.
 